### PR TITLE
feat: support for multiline cells

### DIFF
--- a/tests/test_alignments.py
+++ b/tests/test_alignments.py
@@ -65,3 +65,28 @@ def test_alignment_numeric_data():
         "╚════╩══════════════════════╝"
     )
     assert text == expected
+
+
+def test_alignments_multiline_data():
+    text = t2a(
+        header=["Multiline\nHeader\nCell", "G", "Two\nLines", "R", "S"],
+        body=[[1, "Alpha\nBeta\nGamma", 3, 4, "One\nTwo"]],
+        footer=["A", "Footer\nBreak", 1, "Second\nCell\nBroken", 3],
+        alignments=[Alignment.LEFT, Alignment.RIGHT, Alignment.CENTER, Alignment.LEFT, Alignment.CENTER],
+    )
+    expected = (
+        "╔═══════════════════════════════════════════╗\n"
+        "║ Multiline        G    Two    R         S  ║\n"
+        "║ Header               Lines                ║\n"
+        "║ Cell                                      ║\n"
+        "╟───────────────────────────────────────────╢\n"
+        "║ 1            Alpha     3     4        One ║\n"
+        "║               Beta                    Two ║\n"
+        "║              Gamma                        ║\n"
+        "╟───────────────────────────────────────────╢\n"
+        "║ A           Footer     1     Second    3  ║\n"
+        "║              Break           Cell         ║\n"
+        "║                              Broken       ║\n"
+        "╚═══════════════════════════════════════════╝"
+    )
+    assert text == expected

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -199,3 +199,27 @@ def test_numeric_data():
         "╚════╩══════════════════════╝"
     )
     assert text == expected
+
+
+def test_multiline_cells():
+    text = table = t2a(
+        header=["Multiline\nHeader\nCell", "G", "Two\nLines", "R", "S"],
+        body=[[1, "Alpha\nBeta\nGamma", 3, 4, "One\nTwo"]],
+        footer=["A", "Footer\nBreak", 1, "Second\nCell\nBroken", 3],
+    )
+    expected = (
+        "╔═══════════════════════════════════════════╗\n"
+        "║ Multiline     G       Two      R       S  ║\n"
+        "║  Header              Lines                ║\n"
+        "║   Cell                                    ║\n"
+        "╟───────────────────────────────────────────╢\n"
+        "║     1       Alpha      3       4      One ║\n"
+        "║              Beta                     Two ║\n"
+        "║             Gamma                         ║\n"
+        "╟───────────────────────────────────────────╢\n"
+        "║     A       Footer     1     Second    3  ║\n"
+        "║             Break             Cell        ║\n"
+        "║                              Broken       ║\n"
+        "╚═══════════════════════════════════════════╝"
+    )
+    assert text == expected


### PR DESCRIPTION
Fixes #28

Example

```py
from table2ascii import table2ascii as t2a, PresetStyle, Alignment

table = t2a(
    header=["Multiline\nHeader\nCell", "G", "Two\nLines", "R", "S"],
    body=[[1, "Alpha\nBeta\nGamma", 3, 4, "One\nTwo"]],
    footer=["A", "Footer\nBreak", 1, "Second\nCell\nBroken", 3],
    alignments=[Alignment.LEFT, Alignment.RIGHT, Alignment.CENTER, Alignment.LEFT, Alignment.CENTER],
    style=PresetStyle.ascii_box
)

print(table)
```
```
+-----------+--------+-------+--------+-----+
| Multiline |      G |  Two  | R      |  S  |
| Header    |        | Lines |        |     |
| Cell      |        |       |        |     |
+-----------+--------+-------+--------+-----+
| 1         |  Alpha |   3   | 4      | One |
|           |   Beta |       |        | Two |
|           |  Gamma |       |        |     |
+-----------+--------+-------+--------+-----+
| A         | Footer |   1   | Second |  3  |
|           |  Break |       | Cell   |     |
|           |        |       | Broken |     |
+-----------+--------+-------+--------+-----+
```

