### PR TITLE
docs: Limit table of contents depth to 2 levels

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,5 @@
 :og:description: Python library for converting lists to fancy ASCII tables for displaying in the terminal and on Discord. Install with \`pip install -U table2ascii\`.
+:tocdepth: 2
 
 table2ascii
 ===========


### PR DESCRIPTION
Due to a sphinx update, more levels of the api reference are showing than intended. This sets back the table of contents to only show 2 levels