### PR TITLE
docs: Set table of contents depth for Sphinx 5.x

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,4 @@
 :og:description: Python library for converting lists to fancy ASCII tables for displaying in the terminal and on Discord. Install with \`pip install -U table2ascii\`.
-:tocdepth: 2
 
 table2ascii
 ===========
@@ -21,6 +20,7 @@ Contents
 --------
 
 .. toctree::
+   :maxdepth: 2
 
    usage
    api


### PR DESCRIPTION
Removes `:tocdepth: 2` and adds `:maxdepth: 2` instead to support sphinx 5.x