### PR TITLE
feat: Added `plain` table style

### DIFF
--- a/table2ascii/preset_style.py
+++ b/table2ascii/preset_style.py
@@ -46,3 +46,4 @@ class PresetStyle:
     ascii_rounded = TableStyle.from_string("/===\|| |=|=||-|-|\|=/")
     ascii_rounded_box = TableStyle.from_string("/===\||||=||||-|||\||/")
     markdown = TableStyle.from_string("     ||||-|||         ")
+    plain = TableStyle.from_string("                      ")

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -649,3 +649,21 @@ def test_markdown():
         "| SUM | 130 | 140 | 135 | 130 |"
     )
     assert text == expected
+
+
+def test_plain():
+    text = t2a(
+        header=["#", "G", "H", "R", "S"],
+        body=[["1", "30", "40", "35", "30"], ["2", "30", "40", "35", "30"]],
+        footer=["SUM", "130", "140", "135", "130"],
+        first_col_heading=True,
+        last_col_heading=False,
+        style=PresetStyle.plain,
+    )
+    expected = (
+        "   #     G     H     R     S   \n"
+        "   1    30    40    35    30   \n"
+        "   2    30    40    35    30   \n"
+        "  SUM   130   140   135   130  "
+    )
+    assert text == expected


### PR DESCRIPTION
```
>>> from table2ascii import table2ascii, PresetStyle
>>> print(table2ascii(header=[1,2,3,4],body=[[5,6,7,8],[9,10,11,12]], style=PresetStyle.plain))
  1   2    3    4   
  5   6    7    8   
  9   10   11   12 
```