### PR TITLE
feat: Add `cell_padding` configurable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ print(output)
 ### Use a preset style
 
 ```py
-from table2ascii import table2ascii, PresetStyle
+from table2ascii import table2ascii, Alignment, PresetStyle
 
 output = table2ascii(
     header=["First", "Second", "Third", "Fourth"],
@@ -110,6 +110,22 @@ print(output)
 +----------+----------+----------+----------+
 |    20    |    10    |    20    |    5     |
 +----------+----------+----------+----------+
+"""
+
+output = table2ascii(
+    header=["First", "Second", "Third", "Fourth"],
+    body=[["10", "30", "40", "35"], ["20", "10", "20", "5"]],
+    style=PresetStyle.plain,
+    cell_padding=0,
+    alignments=[Alignment.LEFT] * 4,
+)
+
+print(output)
+
+"""
+First Second Third Fourth
+10    30     40    35
+20    10     20    5
 """
 ```
 
@@ -159,6 +175,7 @@ All parameters are optional.
 |       `style`       |     `TableStyle`      | `double_thin_compact` |                         Table style to use for the table                          |
 | `first_col_heading` |        `bool`         |        `False`        |         Whether to add a heading column seperator after the first column          |
 | `last_col_heading`  |        `bool`         |        `False`        |         Whether to add a heading column seperator before the last column          |
+|   `cell_padding`    |         `int`         |          `1`          | The minimum number of spaces to add between the cell content and the cell border. |
 
 See the [API Reference](https://table2ascii.readthedocs.io/en/latest/api.html) for more info.
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ print(output)
 
 """
 First Second Third Fourth
-10    30     40    35    
-20    10     20    5      
+10    30     40    35
+20    10     20    5
 """
 ```
 
@@ -170,9 +170,11 @@ All parameters are optional.
 |      `footer`       |      `List[Any]`      |        `None`         | Last table row seperated by header row seperator. Values should support `str()`.  |
 |   `column_widths`   | `List[Optional[int]]` |  `None` (automatic)   |                List of column widths in characters for each column                |
 |    `alignments`     |   `List[Alignment]`   | `None` (all centered) | Column alignments<br/>(ex. `[Alignment.LEFT, Alignment.CENTER, Alignment.RIGHT]`) |
-|       `style`       |     `TableStyle`      | `double_thin_compact` |                         Table style to use for the table                          |
+|       `style`       |     `TableStyle`      | `double_thin_compact` |                        Table style to use for the table\*                         |
 | `first_col_heading` |        `bool`         |        `False`        |         Whether to add a heading column seperator after the first column          |
 | `last_col_heading`  |        `bool`         |        `False`        |         Whether to add a heading column seperator before the last column          |
+
+\*See a list of all preset styles [here](https://table2ascii.readthedocs.io/en/latest/styles.html).
 
 See the [API Reference](https://table2ascii.readthedocs.io/en/latest/api.html) for more info.
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ output = table2ascii(
     header=["First", "Second", "Third", "Fourth"],
     body=[["10", "30", "40", "35"], ["20", "10", "20", "5"]],
     style=PresetStyle.plain,
-    extra_padding=False,
+    cell_padding=0,
     alignments=[Alignment.LEFT] * 4,
 )
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ print(output)
 ### Use a preset style
 
 ```py
-from table2ascii import table2ascii, PresetStyle
+from table2ascii import table2ascii, PresetStyle, Alignment
 
 output = table2ascii(
     header=["First", "Second", "Third", "Fourth"],
@@ -110,6 +110,22 @@ print(output)
 +----------+----------+----------+----------+
 |    20    |    10    |    20    |    5     |
 +----------+----------+----------+----------+
+"""
+
+output = table2ascii(
+    header=["First", "Second", "Third", "Fourth"],
+    body=[["10", "30", "40", "35"], ["20", "10", "20", "5"]],
+    style=PresetStyle.plain,
+    extra_padding=False,
+    alignments=[Alignment.LEFT] * 4,
+)
+
+print(output)
+
+"""
+First Second Third Fourth
+10    30     40    35    
+20    10     20    5      
 """
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Documentation and examples are available at [table2ascii.rtfd.io](https://table2
 
 ## 🧑‍💻 Usage
 
-### 🚀 Convert lists to ASCII tables
+### Convert lists to ASCII tables
 
 ```py
 from table2ascii import table2ascii
@@ -43,7 +43,7 @@ print(output)
 """
 ```
 
-### 🏆 Set first or last column headings
+### Set first or last column headings
 
 ```py
 from table2ascii import table2ascii
@@ -63,7 +63,7 @@ print(output)
 """
 ```
 
-### 📰 Set column widths and alignments
+### Set column widths and alignments
 
 ```py
 from table2ascii import table2ascii, Alignment
@@ -88,12 +88,10 @@ print(output)
 """
 ```
 
-### 🎨 Use a preset style
-
-See a list of all preset styles [here](https://table2ascii.readthedocs.io/en/latest/styles.html).
+### Use a preset style
 
 ```py
-from table2ascii import table2ascii, PresetStyle, Alignment
+from table2ascii import table2ascii, PresetStyle
 
 output = table2ascii(
     header=["First", "Second", "Third", "Fourth"],
@@ -113,25 +111,9 @@ print(output)
 |    20    |    10    |    20    |    5     |
 +----------+----------+----------+----------+
 """
-
-output = table2ascii(
-    header=["First", "Second", "Third", "Fourth"],
-    body=[["10", "30", "40", "35"], ["20", "10", "20", "5"]],
-    style=PresetStyle.plain,
-    cell_padding=0,
-    alignments=[Alignment.LEFT] * 4,
-)
-
-print(output)
-
-"""
-First Second Third Fourth
-10    30     40    35
-20    10     20    5
-"""
 ```
 
-### 🎲 Define a custom style
+### Define a custom style
 
 Check [`TableStyle`](https://github.com/DenverCoder1/table2ascii/blob/main/table2ascii/table_style.py) for more info and [`PresetStyle`](https://github.com/DenverCoder1/table2ascii/blob/main/table2ascii/preset_style.py) for examples.
 
@@ -159,6 +141,10 @@ print(output)
 """
 ```
 
+## 🎨 Preset styles
+
+See a list of all preset styles [here](https://table2ascii.readthedocs.io/en/latest/styles.html).
+
 ## ⚙️ Options
 
 All parameters are optional.
@@ -170,24 +156,22 @@ All parameters are optional.
 |      `footer`       |      `List[Any]`      |        `None`         | Last table row seperated by header row seperator. Values should support `str()`.  |
 |   `column_widths`   | `List[Optional[int]]` |  `None` (automatic)   |                List of column widths in characters for each column                |
 |    `alignments`     |   `List[Alignment]`   | `None` (all centered) | Column alignments<br/>(ex. `[Alignment.LEFT, Alignment.CENTER, Alignment.RIGHT]`) |
-|       `style`       |     `TableStyle`      | `double_thin_compact` |                        Table style to use for the table\*                         |
+|       `style`       |     `TableStyle`      | `double_thin_compact` |                         Table style to use for the table                          |
 | `first_col_heading` |        `bool`         |        `False`        |         Whether to add a heading column seperator after the first column          |
 | `last_col_heading`  |        `bool`         |        `False`        |         Whether to add a heading column seperator before the last column          |
-
-\*See a list of all preset styles [here](https://table2ascii.readthedocs.io/en/latest/styles.html).
 
 See the [API Reference](https://table2ascii.readthedocs.io/en/latest/api.html) for more info.
 
 ## 👨‍🎨 Use cases
 
-### 🗨️ Discord messages and embeds
+### Discord messages and embeds
 
 -   Display tables nicely inside markdown code blocks on Discord
 -   Useful for making Discord bots with [Discord.py](https://github.com/Rapptz/discord.py)
 
 ![image](https://user-images.githubusercontent.com/20955511/116203248-2973c600-a744-11eb-97d8-4b75ed2845c9.png)
 
-### 💻 Terminal outputs
+### Terminal outputs
 
 -   Tables display nicely whenever monospace fonts are fully supported
 -   Tables make terminal outputs look more professional

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Documentation and examples are available at [table2ascii.rtfd.io](https://table2
 
 ## 🧑‍💻 Usage
 
-### Convert lists to ASCII tables
+### 🚀 Convert lists to ASCII tables
 
 ```py
 from table2ascii import table2ascii
@@ -43,7 +43,7 @@ print(output)
 """
 ```
 
-### Set first or last column headings
+### 🏆 Set first or last column headings
 
 ```py
 from table2ascii import table2ascii
@@ -63,7 +63,7 @@ print(output)
 """
 ```
 
-### Set column widths and alignments
+### 📰 Set column widths and alignments
 
 ```py
 from table2ascii import table2ascii, Alignment
@@ -88,7 +88,9 @@ print(output)
 """
 ```
 
-### Use a preset style
+### 🎨 Use a preset style
+
+See a list of all preset styles [here](https://table2ascii.readthedocs.io/en/latest/styles.html).
 
 ```py
 from table2ascii import table2ascii, PresetStyle, Alignment
@@ -129,7 +131,7 @@ First Second Third Fourth
 """
 ```
 
-### Define a custom style
+### 🎲 Define a custom style
 
 Check [`TableStyle`](https://github.com/DenverCoder1/table2ascii/blob/main/table2ascii/table_style.py) for more info and [`PresetStyle`](https://github.com/DenverCoder1/table2ascii/blob/main/table2ascii/preset_style.py) for examples.
 
@@ -157,10 +159,6 @@ print(output)
 """
 ```
 
-## 🎨 Preset styles
-
-See a list of all preset styles [here](https://table2ascii.readthedocs.io/en/latest/styles.html).
-
 ## ⚙️ Options
 
 All parameters are optional.
@@ -180,14 +178,14 @@ See the [API Reference](https://table2ascii.readthedocs.io/en/latest/api.html) f
 
 ## 👨‍🎨 Use cases
 
-### Discord messages and embeds
+### 🗨️ Discord messages and embeds
 
 -   Display tables nicely inside markdown code blocks on Discord
 -   Useful for making Discord bots with [Discord.py](https://github.com/Rapptz/discord.py)
 
 ![image](https://user-images.githubusercontent.com/20955511/116203248-2973c600-a744-11eb-97d8-4b75ed2845c9.png)
 
-### Terminal outputs
+### 💻 Terminal outputs
 
 -   Tables display nicely whenever monospace fonts are fully supported
 -   Tables make terminal outputs look more professional

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -79,7 +79,7 @@ Use a preset style
 
 .. code:: py
 
-   from table2ascii import table2ascii, PresetStyle
+   from table2ascii import table2ascii, PresetStyle, Alignment
 
    output = table2ascii(
        header=["First", "Second", "Third", "Fourth"],
@@ -99,6 +99,22 @@ Use a preset style
    |    20    |    10    |    20    |    5     |
    +----------+----------+----------+----------+
    """
+
+    output = table2ascii(
+        header=["First", "Second", "Third", "Fourth"],
+        body=[["10", "30", "40", "35"], ["20", "10", "20", "5"]],
+        style=PresetStyle.plain,
+        extra_padding=False,
+        alignments=[Alignment.LEFT] * 4,
+    )
+
+    print(output)
+
+    """
+    First Second Third Fourth
+    10    30     40    35    
+    20    10     20    5      
+    """
 
 Define a custom style
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -104,7 +104,7 @@ Use a preset style
         header=["First", "Second", "Third", "Fourth"],
         body=[["10", "30", "40", "35"], ["20", "10", "20", "5"]],
         style=PresetStyle.plain,
-        extra_padding=False,
+        cell_padding=0,
         alignments=[Alignment.LEFT] * 4,
     )
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -112,8 +112,8 @@ Use a preset style
 
     """
     First Second Third Fourth
-    10    30     40    35    
-    20    10     20    5      
+    10    30     40    35
+    20    10     20    5
     """
 
 Define a custom style

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -79,7 +79,7 @@ Use a preset style
 
 .. code:: py
 
-   from table2ascii import table2ascii, PresetStyle, Alignment
+   from table2ascii import table2ascii, Alignment, PresetStyle
 
    output = table2ascii(
        header=["First", "Second", "Third", "Fourth"],

--- a/table2ascii/options.py
+++ b/table2ascii/options.py
@@ -13,5 +13,5 @@ class Options:
     last_col_heading: bool
     column_widths: Optional[List[Optional[int]]]
     alignments: Optional[List[Alignment]]
-    style: TableStyle
     cell_padding: int
+    style: TableStyle

--- a/table2ascii/options.py
+++ b/table2ascii/options.py
@@ -14,3 +14,4 @@ class Options:
     column_widths: Optional[List[Optional[int]]]
     alignments: Optional[List[Alignment]]
     style: TableStyle
+    extra_padding: bool

--- a/table2ascii/options.py
+++ b/table2ascii/options.py
@@ -14,4 +14,4 @@ class Options:
     column_widths: Optional[List[Optional[int]]]
     alignments: Optional[List[Alignment]]
     style: TableStyle
-    extra_padding: bool
+    cell_padding: int

--- a/table2ascii/table_to_ascii.py
+++ b/table2ascii/table_to_ascii.py
@@ -34,7 +34,7 @@ class TableToAscii:
         self.__style = options.style
         self.__first_col_heading = options.first_col_heading
         self.__last_col_heading = options.last_col_heading
-        self.__extra_padding = options.extra_padding
+        self.__cell_padding = options.cell_padding
 
         # calculate number of columns
         self.__columns = self.__count_columns()
@@ -109,10 +109,8 @@ class TableToAscii:
             header_size = widest_line(self.__header[i]) if self.__header else 0
             body_size = max(widest_line(row[i]) for row in self.__body) if self.__body else 0
             footer_size = widest_line(self.__footer[i]) if self.__footer else 0
-            # get the max and add 2 for padding each side with a space if extra_padding is True
-            column_widths.append(
-                max(header_size, body_size, footer_size) + self.__extra_padding * 2
-            )
+            # get the max and add 2 for padding each side with a space depending on cell padding
+            column_widths.append(max(header_size, body_size, footer_size) + self.__cell_padding * 2)
         return column_widths
 
     def __pad(self, cell_value: SupportsStr, width: int, alignment: Alignment) -> str:
@@ -128,7 +126,8 @@ class TableToAscii:
             The padded text
         """
         text = str(cell_value)
-        padded_text = f" {text} " if self.__extra_padding else text
+        padding = " " * self.__cell_padding
+        padded_text = f"{padding}{text}{padding}"
         if alignment == Alignment.LEFT:
             # pad with spaces on the end
             return padded_text + (" " * (width - len(padded_text)))
@@ -323,7 +322,7 @@ def table2ascii(
     column_widths: Optional[List[Optional[int]]] = None,
     alignments: Optional[List[Alignment]] = None,
     style: TableStyle = PresetStyle.double_thin_compact,
-    extra_padding: bool = True,
+    cell_padding: int = 1,
 ) -> str:
     """
     Convert a 2D Python table to ASCII text
@@ -348,9 +347,9 @@ def table2ascii(
             :py:obj:`None`, all columns will be center-aligned. Defaults to :py:obj:`None`.
         style: Table style to use for styling (preset styles can be imported).
             Defaults to :ref:`PresetStyle.double_thin_compact <PresetStyle.double_thin_compact>`.
-        extra_padding: Whether to add at least one space of padding before and after each cell value.
-            If :py:obj:`False`, the cell value will be printed directly next to the column separator.
-            Defaults to :py:obj:`True`.
+        cell_padding: The minimum number of spaces to add between the cell content and the cell border.
+            If this is set to ``0``, the cell content will be printed directly next to the column
+            separator. Defaults to ``1``.
 
     Returns:
         The generated ASCII table
@@ -365,6 +364,6 @@ def table2ascii(
             column_widths=column_widths,
             alignments=alignments,
             style=style,
-            extra_padding=extra_padding,
+            cell_padding=cell_padding,
         ),
     ).to_ascii()

--- a/table2ascii/table_to_ascii.py
+++ b/table2ascii/table_to_ascii.py
@@ -72,6 +72,10 @@ class TableToAscii:
         if options.alignments and len(options.alignments) != self.__columns:
             raise ValueError("Length of `alignments` list must equal the number of columns")
 
+        # check if the cell padding is valid
+        if self.__cell_padding < 0:
+            raise ValueError("Cell padding must be greater than or equal to 0")
+
     def __count_columns(self) -> int:
         """
         Get the number of columns in the table based on the

--- a/table2ascii/table_to_ascii.py
+++ b/table2ascii/table_to_ascii.py
@@ -110,7 +110,9 @@ class TableToAscii:
             body_size = max(widest_line(row[i]) for row in self.__body) if self.__body else 0
             footer_size = widest_line(self.__footer[i]) if self.__footer else 0
             # get the max and add 2 for padding each side with a space if extra_padding is True
-            column_widths.append(max(header_size, body_size, footer_size) + self.__extra_padding * 2)
+            column_widths.append(
+                max(header_size, body_size, footer_size) + self.__extra_padding * 2
+            )
         return column_widths
 
     def __pad(self, cell_value: SupportsStr, width: int, alignment: Alignment) -> str:

--- a/table2ascii/table_to_ascii.py
+++ b/table2ascii/table_to_ascii.py
@@ -34,6 +34,7 @@ class TableToAscii:
         self.__style = options.style
         self.__first_col_heading = options.first_col_heading
         self.__last_col_heading = options.last_col_heading
+        self.__extra_padding = options.extra_padding
 
         # calculate number of columns
         self.__columns = self.__count_columns()
@@ -108,8 +109,8 @@ class TableToAscii:
             header_size = widest_line(self.__header[i]) if self.__header else 0
             body_size = max(widest_line(row[i]) for row in self.__body) if self.__body else 0
             footer_size = widest_line(self.__footer[i]) if self.__footer else 0
-            # get the max and add 2 for padding each side with a space
-            column_widths.append(max(header_size, body_size, footer_size) + 2)
+            # get the max and add 2 for padding each side with a space if extra_padding is True
+            column_widths.append(max(header_size, body_size, footer_size) + self.__extra_padding * 2)
         return column_widths
 
     def __pad(self, cell_value: SupportsStr, width: int, alignment: Alignment) -> str:
@@ -125,17 +126,18 @@ class TableToAscii:
             The padded text
         """
         text = str(cell_value)
+        padded_text = f" {text} " if self.__extra_padding else text
         if alignment == Alignment.LEFT:
             # pad with spaces on the end
-            return f" {text} " + (" " * (width - len(text) - 2))
+            return padded_text + (" " * (width - len(padded_text)))
         if alignment == Alignment.CENTER:
             # pad with spaces, half on each side
-            before = " " * floor((width - len(text) - 2) / 2)
-            after = " " * ceil((width - len(text) - 2) / 2)
-            return before + f" {text} " + after
+            before = " " * floor((width - len(padded_text)) / 2)
+            after = " " * ceil((width - len(padded_text)) / 2)
+            return before + padded_text + after
         if alignment == Alignment.RIGHT:
             # pad with spaces at the beginning
-            return (" " * (width - len(text) - 2)) + f" {text} "
+            return (" " * (width - len(padded_text))) + padded_text
         raise ValueError(f"The value '{alignment}' is not valid for alignment.")
 
     def __row_to_ascii(
@@ -319,6 +321,7 @@ def table2ascii(
     column_widths: Optional[List[Optional[int]]] = None,
     alignments: Optional[List[Alignment]] = None,
     style: TableStyle = PresetStyle.double_thin_compact,
+    extra_padding: bool = True,
 ) -> str:
     """
     Convert a 2D Python table to ASCII text
@@ -343,6 +346,9 @@ def table2ascii(
             :py:obj:`None`, all columns will be center-aligned. Defaults to :py:obj:`None`.
         style: Table style to use for styling (preset styles can be imported).
             Defaults to :ref:`PresetStyle.double_thin_compact <PresetStyle.double_thin_compact>`.
+        extra_padding: Whether to add at least one space of padding before and after each cell value.
+            If :py:obj:`False`, the cell value will be printed directly next to the column separator.
+            Defaults to :py:obj:`True`.
 
     Returns:
         The generated ASCII table
@@ -357,5 +363,6 @@ def table2ascii(
             column_widths=column_widths,
             alignments=alignments,
             style=style,
+            extra_padding=extra_padding,
         ),
     ).to_ascii()

--- a/table2ascii/table_to_ascii.py
+++ b/table2ascii/table_to_ascii.py
@@ -321,8 +321,8 @@ def table2ascii(
     last_col_heading: bool = False,
     column_widths: Optional[List[Optional[int]]] = None,
     alignments: Optional[List[Alignment]] = None,
-    style: TableStyle = PresetStyle.double_thin_compact,
     cell_padding: int = 1,
+    style: TableStyle = PresetStyle.double_thin_compact,
 ) -> str:
     """
     Convert a 2D Python table to ASCII text
@@ -345,11 +345,11 @@ def table2ascii(
         alignments: List of alignments for each column
             (ex. ``[Alignment.LEFT, Alignment.CENTER, Alignment.RIGHT]``). If not specified or set to
             :py:obj:`None`, all columns will be center-aligned. Defaults to :py:obj:`None`.
-        style: Table style to use for styling (preset styles can be imported).
-            Defaults to :ref:`PresetStyle.double_thin_compact <PresetStyle.double_thin_compact>`.
         cell_padding: The minimum number of spaces to add between the cell content and the cell border.
             If this is set to ``0``, the cell content will be printed directly next to the column
             separator. Defaults to ``1``.
+        style: Table style to use for styling (preset styles can be imported).
+            Defaults to :ref:`PresetStyle.double_thin_compact <PresetStyle.double_thin_compact>`.
 
     Returns:
         The generated ASCII table
@@ -363,7 +363,7 @@ def table2ascii(
             last_col_heading=last_col_heading,
             column_widths=column_widths,
             alignments=alignments,
-            style=style,
             cell_padding=cell_padding,
+            style=style,
         ),
     ).to_ascii()

--- a/table2ascii/table_to_ascii.py
+++ b/table2ascii/table_to_ascii.py
@@ -345,9 +345,9 @@ def table2ascii(
         alignments: List of alignments for each column
             (ex. ``[Alignment.LEFT, Alignment.CENTER, Alignment.RIGHT]``). If not specified or set to
             :py:obj:`None`, all columns will be center-aligned. Defaults to :py:obj:`None`.
-        cell_padding: The minimum number of spaces to add between the cell content and the cell border.
-            If this is set to ``0``, the cell content will be printed directly next to the column
-            separator. Defaults to ``1``.
+        cell_padding: The minimum number of spaces to add between the cell content and the column
+            separator. If set to ``0``, the cell content will be flush against the column separator.
+            Defaults to ``1``.
         style: Table style to use for styling (preset styles can be imported).
             Defaults to :ref:`PresetStyle.double_thin_compact <PresetStyle.double_thin_compact>`.
 

--- a/tests/test_cell_padding.py
+++ b/tests/test_cell_padding.py
@@ -1,0 +1,82 @@
+import pytest
+
+from table2ascii import Alignment, table2ascii as t2a
+
+
+def test_without_cell_padding():
+    text = t2a(
+        header=["#", "G", "H", "R", "S"],
+        body=[[1, 2, 3, 4, 5]],
+        footer=["A", "B", 1, 2, 3],
+        first_col_heading=True,
+        cell_padding=0,
+    )
+    expected = (
+        "╔═╦═══════╗\n"
+        "║#║G H R S║\n"
+        "╟─╫───────╢\n"
+        "║1║2 3 4 5║\n"
+        "╟─╫───────╢\n"
+        "║A║B 1 2 3║\n"
+        "╚═╩═══════╝"
+    )
+    assert text == expected
+
+
+def test_column_width_and_alignment_without_cell_padding():
+    text = t2a(
+        header=["#", "G", "H", "R", "S"],
+        body=[[1, 2, 3, 4, 5]],
+        footer=["A", "B", 1, 2, 3],
+        column_widths=[4, 8, 5, 4, 5],
+        alignments=[
+            Alignment.LEFT,
+            Alignment.CENTER,
+            Alignment.RIGHT,
+            Alignment.LEFT,
+            Alignment.RIGHT,
+        ],
+        first_col_heading=True,
+        cell_padding=0,
+    )
+    expected = (
+        "╔════╦═════════════════════════╗\n"
+        "║#   ║   G         H R        S║\n"
+        "╟────╫─────────────────────────╢\n"
+        "║1   ║   2         3 4        5║\n"
+        "╟────╫─────────────────────────╢\n"
+        "║A   ║   B         1 2        3║\n"
+        "╚════╩═════════════════════════╝"
+    )
+    assert text == expected
+
+
+def test_cell_padding_more_than_one():
+    text = t2a(
+        header=["#", "G", "H", "R", "S"],
+        body=[[1, 2, 3, 4, 5]],
+        footer=["A", "B", 1, 2, 3],
+        first_col_heading=True,
+        cell_padding=2,
+    )
+    expected = (
+        "╔═════╦═══════════════════════╗\n"
+        "║  #  ║  G     H     R     S  ║\n"
+        "╟─────╫───────────────────────╢\n"
+        "║  1  ║  2     3     4     5  ║\n"
+        "╟─────╫───────────────────────╢\n"
+        "║  A  ║  B     1     2     3  ║\n"
+        "╚═════╩═══════════════════════╝"
+    )
+    assert text == expected
+
+
+def test_negative_cell_padding():
+    with pytest.raises(ValueError):
+        t2a(
+            header=["#", "G", "H", "R", "S"],
+            body=[[1, 2, 3, 4, 5]],
+            footer=["A", "B", 1, 2, 3],
+            first_col_heading=True,
+            cell_padding=-1,
+        )

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,6 +1,6 @@
 import pytest
 
-from table2ascii import Alignment, table2ascii as t2a
+from table2ascii import table2ascii as t2a
 
 
 def test_header_body_footer():
@@ -246,82 +246,3 @@ def test_multiline_cells():
         "╚═══════════════════════════════════════════╝"
     )
     assert text == expected
-
-
-def test_without_cell_padding():
-    text = t2a(
-        header=["#", "G", "H", "R", "S"],
-        body=[[1, 2, 3, 4, 5]],
-        footer=["A", "B", 1, 2, 3],
-        first_col_heading=True,
-        cell_padding=0,
-    )
-    expected = (
-        "╔═╦═══════╗\n"
-        "║#║G H R S║\n"
-        "╟─╫───────╢\n"
-        "║1║2 3 4 5║\n"
-        "╟─╫───────╢\n"
-        "║A║B 1 2 3║\n"
-        "╚═╩═══════╝"
-    )
-    assert text == expected
-
-
-def test_column_width_and_alignment_without_cell_padding():
-    text = t2a(
-        header=["#", "G", "H", "R", "S"],
-        body=[[1, 2, 3, 4, 5]],
-        footer=["A", "B", 1, 2, 3],
-        column_widths=[4, 8, 5, 4, 5],
-        alignments=[
-            Alignment.LEFT,
-            Alignment.CENTER,
-            Alignment.RIGHT,
-            Alignment.LEFT,
-            Alignment.RIGHT,
-        ],
-        first_col_heading=True,
-        cell_padding=0,
-    )
-    expected = (
-        "╔════╦═════════════════════════╗\n"
-        "║#   ║   G         H R        S║\n"
-        "╟────╫─────────────────────────╢\n"
-        "║1   ║   2         3 4        5║\n"
-        "╟────╫─────────────────────────╢\n"
-        "║A   ║   B         1 2        3║\n"
-        "╚════╩═════════════════════════╝"
-    )
-    assert text == expected
-
-
-def test_cell_padding_more_than_one():
-    text = t2a(
-        header=["#", "G", "H", "R", "S"],
-        body=[[1, 2, 3, 4, 5]],
-        footer=["A", "B", 1, 2, 3],
-        first_col_heading=True,
-        cell_padding=2,
-    )
-    expected = (
-        "╔═════╦═══════════════════════╗\n"
-        "║  #  ║  G     H     R     S  ║\n"
-        "╟─────╫───────────────────────╢\n"
-        "║  1  ║  2     3     4     5  ║\n"
-        "╟─────╫───────────────────────╢\n"
-        "║  A  ║  B     1     2     3  ║\n"
-        "╚═════╩═══════════════════════╝"
-    )
-    assert text == expected
-
-
-def test_negative_cell_padding():
-    with pytest.raises(ValueError):
-        t2a(
-            header=["#", "G", "H", "R", "S"],
-            body=[[1, 2, 3, 4, 5]],
-            footer=["A", "B", 1, 2, 3],
-            first_col_heading=True,
-            cell_padding=-1,
-        )

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,6 +1,6 @@
 import pytest
 
-from table2ascii import table2ascii as t2a, Alignment
+from table2ascii import Alignment, table2ascii as t2a
 
 
 def test_header_body_footer():

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -248,13 +248,13 @@ def test_multiline_cells():
     assert text == expected
 
 
-def test_without_extra_padding():
+def test_without_cell_padding():
     text = t2a(
         header=["#", "G", "H", "R", "S"],
         body=[[1, 2, 3, 4, 5]],
         footer=["A", "B", 1, 2, 3],
         first_col_heading=True,
-        extra_padding=False,
+        cell_padding=0,
     )
     expected = (
         "╔═╦═══════╗\n"
@@ -268,7 +268,7 @@ def test_without_extra_padding():
     assert text == expected
 
 
-def test_column_width_and_alignment_without_extra_padding():
+def test_column_width_and_alignment_without_cell_padding():
     text = t2a(
         header=["#", "G", "H", "R", "S"],
         body=[[1, 2, 3, 4, 5]],
@@ -282,7 +282,7 @@ def test_column_width_and_alignment_without_extra_padding():
             Alignment.RIGHT,
         ],
         first_col_heading=True,
-        extra_padding=False,
+        cell_padding=0,
     )
     expected = (
         "╔════╦═════════════════════════╗\n"
@@ -292,5 +292,25 @@ def test_column_width_and_alignment_without_extra_padding():
         "╟────╫─────────────────────────╢\n"
         "║A   ║   B         1 2        3║\n"
         "╚════╩═════════════════════════╝"
+    )
+    assert text == expected
+
+
+def test_cell_padding_more_than_one():
+    text = t2a(
+        header=["#", "G", "H", "R", "S"],
+        body=[[1, 2, 3, 4, 5]],
+        footer=["A", "B", 1, 2, 3],
+        first_col_heading=True,
+        cell_padding=2,
+    )
+    expected = (
+        "╔═════╦═══════════════════════╗\n"
+        "║  #  ║  G     H     R     S  ║\n"
+        "╟─────╫───────────────────────╢\n"
+        "║  1  ║  2     3     4     5  ║\n"
+        "╟─────╫───────────────────────╢\n"
+        "║  A  ║  B     1     2     3  ║\n"
+        "╚═════╩═══════════════════════╝"
     )
     assert text == expected

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,6 +1,6 @@
 import pytest
 
-from table2ascii import table2ascii as t2a
+from table2ascii import table2ascii as t2a, Alignment
 
 
 def test_header_body_footer():
@@ -244,5 +244,53 @@ def test_multiline_cells():
         "║             Break             Cell        ║\n"
         "║                              Broken       ║\n"
         "╚═══════════════════════════════════════════╝"
+    )
+    assert text == expected
+
+
+def test_without_extra_padding():
+    text = t2a(
+        header=["#", "G", "H", "R", "S"],
+        body=[[1, 2, 3, 4, 5]],
+        footer=["A", "B", 1, 2, 3],
+        first_col_heading=True,
+        extra_padding=False,
+    )
+    expected = (
+        "╔═╦═══════╗\n"
+        "║#║G H R S║\n"
+        "╟─╫───────╢\n"
+        "║1║2 3 4 5║\n"
+        "╟─╫───────╢\n"
+        "║A║B 1 2 3║\n"
+        "╚═╩═══════╝"
+    )
+    assert text == expected
+
+
+def test_column_width_and_alignment_without_extra_padding():
+    text = t2a(
+        header=["#", "G", "H", "R", "S"],
+        body=[[1, 2, 3, 4, 5]],
+        footer=["A", "B", 1, 2, 3],
+        column_widths=[4, 8, 5, 4, 5],
+        alignments=[
+            Alignment.LEFT,
+            Alignment.CENTER,
+            Alignment.RIGHT,
+            Alignment.LEFT,
+            Alignment.RIGHT,
+        ],
+        first_col_heading=True,
+        extra_padding=False,
+    )
+    expected = (
+        "╔════╦═════════════════════════╗\n"
+        "║#   ║   G         H R        S║\n"
+        "╟────╫─────────────────────────╢\n"
+        "║1   ║   2         3 4        5║\n"
+        "╟────╫─────────────────────────╢\n"
+        "║A   ║   B         1 2        3║\n"
+        "╚════╩═════════════════════════╝"
     )
     assert text == expected

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -314,3 +314,14 @@ def test_cell_padding_more_than_one():
         "╚═════╩═══════════════════════╝"
     )
     assert text == expected
+
+
+def test_negative_cell_padding():
+    with pytest.raises(ValueError):
+        t2a(
+            header=["#", "G", "H", "R", "S"],
+            body=[[1, 2, 3, 4, 5]],
+            footer=["A", "B", 1, 2, 3],
+            first_col_heading=True,
+            cell_padding=-1,
+        )


### PR DESCRIPTION
Adds an option to configure the amount of cell padding.

```py
table2ascii(
    header=["#", "G", "H", "R", "S"],
    body=[[1, 2, 3, 4, 5]],
    footer=["A", "B", 1, 2, 3],
    first_col_heading=True,
    cell_padding=0,
)

╔═╦═══════╗
║#║G H R S║
╟─╫───────╢
║1║2 3 4 5║
╟─╫───────╢
║A║B 1 2 3║
╚═╩═══════╝
```

```py
table2ascii(
    header=["#", "G", "H", "R", "S"],
    body=[[1, 2, 3, 4, 5]],
    footer=["A", "B", 1, 2, 3],
    first_col_heading=True,
    cell_padding=2,
)

╔═════╦═══════════════════════╗
║  #  ║  G     H     R     S  ║
╟─────╫───────────────────────╢
║  1  ║  2     3     4     5  ║
╟─────╫───────────────────────╢
║  A  ║  B     1     2     3  ║
╚═════╩═══════════════════════╝
```