### PR TITLE
docs: fix code alignment in example usage

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -100,21 +100,21 @@ Use a preset style
    +----------+----------+----------+----------+
    """
 
-    output = table2ascii(
-        header=["First", "Second", "Third", "Fourth"],
-        body=[["10", "30", "40", "35"], ["20", "10", "20", "5"]],
-        style=PresetStyle.plain,
-        cell_padding=0,
-        alignments=[Alignment.LEFT] * 4,
-    )
-
-    print(output)
-
-    """
-    First Second Third Fourth
-    10    30     40    35
-    20    10     20    5
-    """
+   output = table2ascii(
+       header=["First", "Second", "Third", "Fourth"],
+       body=[["10", "30", "40", "35"], ["20", "10", "20", "5"]],
+       style=PresetStyle.plain,
+       cell_padding=0,
+       alignments=[Alignment.LEFT] * 4,
+   )
+   
+   print(output)
+   
+   """
+   First Second Third Fourth
+   10    30     40    35
+   20    10     20    5
+   """
 
 Define a custom style
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -107,9 +107,9 @@ Use a preset style
        cell_padding=0,
        alignments=[Alignment.LEFT] * 4,
    )
-   
+
    print(output)
-   
+
    """
    First Second Third Fourth
    10    30     40    35


### PR DESCRIPTION
Part of the documentation is indented differently than the rest of the code

![image](https://user-images.githubusercontent.com/20955511/198920652-7551cf47-75c8-45b8-8735-ed44456341c5.png)

This fixes the spacing so it is aligned properly.

![image](https://user-images.githubusercontent.com/20955511/198920694-326264d6-5b93-443e-8f3f-a38d40126a3e.png)
