### PR TITLE
fix: make dependencies and other build arguments static

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -94,7 +94,7 @@ jobs:
             setup.py
 
       - name: Install dependencies
-        run: python -m pip install -r requirements.txt -e ".[dev]" -e ".[docs]"
+        run: python -m pip install -e ".[dev]" -e ".[docs]"
 
       - name: Run mypy
         run: mypy .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
             setup.py
 
       - name: Install dependencies
-        run: python -m pip install -r requirements.txt -e ".[dev]"
+        run: python -m pip install -e ".[dev]"
 
       - name: Set up pyright
         run: echo "PYRIGHT_VERSION=$(python -c 'import pyright; print(pyright.__pyright_version__)')" >> $GITHUB_ENV

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt -e ".[dev]"
+          python -m pip install -e ".[dev]"
           python -m pip install --pre tox-gh-actions
       - name: Test with pytest
         run: tox

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt -e ".[dev]"
+          python -m pip install -e ".[dev]"
           python -m pip install --pre tox-gh-actions
       - name: Test with pytest
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "table2ascii"
 authors = [{name = "Jonah Lawrence", email = "jonah@freshidea.com"}]
-dynamic = ["version", "description", "readme", "dependencies", "optional-dependencies"]
+dynamic = ["version", "description", "readme", "optional-dependencies"]
 requires-python = ">=3.7"
 license = {file = "LICENSE"}
 keywords = ["table", "ascii", "unicode", "formatter"]
@@ -37,6 +37,10 @@ classifiers = [
     "Topic :: Printing",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
+]
+dependencies = [
+    "typing-extensions >= 3.7.4; python_version < '3.8'",
+    "wcwidth < 1",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,14 @@
 [build-system]
-requires = [
-    "setuptools>=42",
-    "wheel"
-]
+requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"
 
 
 [project]
 name = "table2ascii"
 authors = [{name = "Jonah Lawrence", email = "jonah@freshidea.com"}]
-dynamic = ["version", "description", "readme", "optional-dependencies"]
+dynamic = ["version"]
+description = "Convert 2D Python lists into Unicode/ASCII tables"
+readme = "README.md"
 requires-python = ">=3.7"
 license = {file = "LICENSE"}
 keywords = ["table", "ascii", "unicode", "formatter"]
@@ -39,10 +38,29 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "typing-extensions >= 3.7.4; python_version < '3.8'",
-    "wcwidth < 1",
+    "typing-extensions>=3.7.4; python_version<'3.8'",
+    "wcwidth<1",
 ]
 
+[project.optional-dependencies]
+docs = [
+    "enum-tools",
+    "sphinx",
+    "sphinx-autobuild",
+    "sphinx-toolbox",
+    "sphinxcontrib_trio",
+    "sphinxext-opengraph",
+    "sphinx-book-theme==0.3.3",
+]
+dev = [
+    "mypy>=0.982,<1",
+    "pre-commit>=2.0.0,<3",
+    "pyright>=1.0.0,<2",
+    "pytest>=6.0.0,<8",
+    "slotscheck>=0.1.0,<1",
+    "taskipy>=1.0.0,<2",
+    "tox>=3.0.0,<5",
+]
 
 [project.urls]
 documentation = "https://table2ascii.rtfd.io"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-typing-extensions>=3.7.4; python_version<'3.8'
-wcwidth<1

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 # /usr/bin/env python
-import os
 import re
 
 from setuptools import setup
@@ -14,57 +13,4 @@ def version():
     return version.group(1)
 
 
-def long_description():
-    # check if README.md exists
-    if not os.path.exists("README.md"):
-        return ""
-    with open("README.md", "r", encoding="utf-8") as fh:
-        return fh.read()
-
-
-def requirements():
-    # check if requirements.txt exists
-    if not os.path.exists("requirements.txt"):
-        return []
-    with open("requirements.txt") as f:
-        return f.read().splitlines()
-
-
-extras_require = {
-    "docs": [
-        "enum-tools",
-        "sphinx",
-        "sphinx-autobuild",
-        "sphinx-toolbox",
-        "sphinxcontrib_trio",
-        "sphinxext-opengraph",
-        "sphinx-book-theme==0.3.3",
-    ],
-    "dev": [
-        "mypy>=0.982,<1",
-        "pre-commit>=2.0.0,<3",
-        "pyright>=1.0.0,<2",
-        "pytest>=6.0.0,<8",
-        "slotscheck>=0.1.0,<1",
-        "taskipy>=1.0.0,<2",
-        "tox>=3.0.0,<5",
-    ],
-}
-
-setup(
-    name="table2ascii",
-    version=version(),
-    author="Jonah Lawrence",
-    author_email="jonah@freshidea.com",
-    description="Convert 2D Python lists into Unicode/Ascii tables",
-    long_description=long_description(),
-    long_description_content_type="text/markdown",
-    url="https://github.com/DenverCoder1/table2ascii",
-    packages=["table2ascii"],
-    install_requires=requirements(),
-    extras_require=extras_require,
-    setup_requires=[],
-    tests_require=[
-        "pytest>=6.2,<8",
-    ],
-)
+setup(name="table2ascii", version=version())

--- a/table2ascii/__init__.py
+++ b/table2ascii/__init__.py
@@ -8,7 +8,7 @@ from .preset_style import PresetStyle
 from .table_style import TableStyle
 from .table_to_ascii import table2ascii
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 __all__ = [
     "Alignment",

--- a/tox.ini
+++ b/tox.ini
@@ -4,5 +4,4 @@ envlist = py37, py38, py39, py310, py311
 [testenv]
 deps =
     pytest
-    -rrequirements.txt
 commands = pytest tests -s


### PR DESCRIPTION
I tried to install version 1.0.3 with pip and it doesn't install the dependencies. Figured out that requirements.txt is not included in the [source distribution](https://files.pythonhosted.org/packages/11/97/9e9f22b9276cd1631592b0453a1ebef6e7b77df8b3c129e6fca17ce7d39a/table2ascii-1.0.3.tar.gz), hence giving the install_requires an empty array. I assume this doesn't happen on 1.0.1 because it has a [wheel file](https://files.pythonhosted.org/packages/08/47/695175b33d4d9ba1db451bf3f9d0d8e9daa0ff5b7541edba0587ab25cd21/table2ascii-1.0.1-py3-none-any.whl).

So, I thought that making the dependencies explicit is better.

References:
[same issue with wheel](https://stackoverflow.com/questions/58881683/pip-does-not-install-my-package-dependencies)