### PR TITLE
fix: Include py.typed in package data for mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "table2ascii"
-version = "1.1.0"
+version = "1.1.1"
 authors = [{name = "Jonah Lawrence", email = "jonah@freshidea.com"}]
 description = "Convert 2D Python lists into Unicode/ASCII tables"
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
 # /usr/bin/env python
 from setuptools import setup
 
-setup()
+setup(
+    packages=["table2ascii"],
+    package_data={"table2ascii": ["py.typed"]},
+)


### PR DESCRIPTION
The `py.typed` file hasn't been included in wheels published to PyPI. This means that with `pip install` table2ascii locally, mypy still doesn't recognize it as a typed library. Running mypy on a file with just `import table2ascii` in it results in this output from mypy:

```py
error: Skipping analyzing "table2ascii": module is installed, but missing library stubs or py.typed marker  [import]
note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```