### PR TITLE
chore: Update documentation and bump version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
       - name: Checkout code
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.14"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.14'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python-update-docs.yml
+++ b/.github/workflows/python-update-docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.14']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.14']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ formats: []
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.11"
+    python: "3.14"
 
 sphinx:
   configuration: docs/source/conf.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dev = [
     "slotscheck>=0.1.0,<1",
     "taskipy>=1.0.0,<2",
     "tox>=3.0.0,<5",
+    "setuptools>=42; python_version>='3.12'",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42"]
+requires = ["setuptools>=66.1.0"]
 build-backend = "setuptools.build_meta"
 
 
@@ -66,7 +66,7 @@ dev = [
     "slotscheck>=0.1.0,<1",
     "taskipy>=1.0.0,<2",
     "tox>=3.0.0,<5",
-    "setuptools>=42; python_version>='3.12'",
+    "setuptools>=66.1.0; python_version>='3.12'",
 ]
 
 [project.urls]
@@ -77,7 +77,7 @@ repository = "https://github.com/DenverCoder1/table2ascii"
 
 [tool.black]
 line-length = 100
-target-version = ["py38", "py39", "py310", "py311", "py312", "py313", "py314"]
+target-version = ["py38", "py39", "py310", "py311", "py312", "py313"]
 
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "table2ascii"
-version = "1.1.3"
+version = "1.2.0"
 authors = [{name = "Jonah Lawrence", email = "jonah@freshidea.com"}]
 description = "Convert 2D Python lists into Unicode/ASCII tables"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Multimedia :: Graphics :: Presentation",
     "Topic :: Utilities",
     "Topic :: Text Processing :: General",
@@ -73,7 +76,7 @@ repository = "https://github.com/DenverCoder1/table2ascii"
 
 [tool.black]
 line-length = 100
-target-version = ["py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311", "py312", "py313", "py314"]
 
 
 [tool.isort]
@@ -129,7 +132,7 @@ reportUnnecessaryTypeIgnoreComment = true
 
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.14"
 namespace_packages = true
 
 

--- a/table2ascii/table_to_ascii.py
+++ b/table2ascii/table_to_ascii.py
@@ -727,6 +727,10 @@ def table2ascii(
             zero-width space, etc.), whereas :func:`len` determines the width solely based on the number of
             characters in the string. Defaults to :py:obj:`True`.
 
+            .. versionchanged:: 1.2.0
+                ``use_wcwidth`` now uses the :func:`wcwidth.width` function from the ``wcwidth`` package
+                instead of :func:`wcwidth.wcswidth` to better handle terminal control codes, escape sequences,
+                certain emoji sequences, and other strings with mixed-width characters.
             .. versionadded:: 1.0.0
 
     Returns:


### PR DESCRIPTION
This pull request updates the `table2ascii` package to version 1.2.0 and improves how string widths are calculated for table formatting. The most significant change is the switch to using `wcwidth.width` instead of `wcwidth.wcswidth` for the `use_wcwidth` option, which provides better handling of terminal control codes, escape sequences, and mixed-width characters.

Version update:

* Bumped the package version from 1.1.3 to 1.2.0 in `pyproject.toml` to reflect the new release.

String width calculation improvement:

* Updated the `use_wcwidth` option in the `table2ascii` function to use `wcwidth.width` instead of `wcwidth.wcswidth`, improving support for terminal control codes, escape sequences, and mixed-width characters. This change is documented in the function's docstring.